### PR TITLE
Generate video from image and text prompt

### DIFF
--- a/ltx_video_app.ipynb
+++ b/ltx_video_app.ipynb
@@ -1,0 +1,209 @@
+# LTX-Video offline-ready hybrid text+image + Gradio UI (1–10 refs, 1s–10m)
+import os, sys, subprocess, math, tempfile, time
+from typing import List, Optional, Tuple
+
+# Optional installs (set True if online)
+ENABLE_INSTALL = False
+REQ = [
+    "torch", "diffusers", "transformers", "accelerate", "safetensors",
+    "gradio", "imageio", "imageio-ffmpeg", "opencv-python", "huggingface_hub",
+    "Pillow", "numpy"
+]
+missing = []
+for pkg in REQ:
+    try:
+        __import__(pkg.replace('-', '_'))
+    except Exception:
+        missing.append(pkg)
+print("Python:", sys.version)
+print("Missing:", missing)
+if ENABLE_INSTALL and missing:
+    subprocess.run([sys.executable, "-m", "pip", "install", "-U", *missing], check=False)
+
+import numpy as np
+import torch
+from PIL import Image
+from diffusers import DiffusionPipeline
+from diffusers.utils import export_to_video
+import gradio as gr
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+DTYPE = (torch.float16 if DEVICE == "cuda" and not torch.cuda.is_bf16_supported()
+         else (torch.bfloat16 if DEVICE == "cuda" else torch.float32))
+MODEL_ID = os.environ.get("LTX_MODEL_ID", "Lightricks/LTX-Video")
+LOCAL_MODEL_DIR = os.environ.get("LTX_MODEL_LOCAL", "")
+
+
+def load_model(model_id: str = MODEL_ID,
+               device: str = DEVICE,
+               dtype: torch.dtype = DTYPE,
+               local_dir: Optional[str] = LOCAL_MODEL_DIR) -> DiffusionPipeline:
+    kwargs = dict(torch_dtype=dtype)
+    if local_dir and os.path.isdir(local_dir):
+        pipe = DiffusionPipeline.from_pretrained(local_dir, **kwargs)
+    else:
+        pipe = DiffusionPipeline.from_pretrained(model_id, **kwargs)
+    pipe.to(device)
+    if hasattr(pipe, "enable_model_cpu_offload") and device == "cpu":
+        pipe.enable_model_cpu_offload()
+    if hasattr(pipe, "enable_xformers_memory_efficient_attention"):
+        try:
+            pipe.enable_xformers_memory_efficient_attention()
+        except Exception:
+            pass
+    return pipe
+
+
+PIPE = load_model()
+
+
+def _clamp_duration_seconds(seconds: float) -> int:
+    seconds = max(1.0, min(float(seconds), 600.0))
+    return int(math.ceil(seconds))
+
+
+def _load_refs(images: List[Image.Image]) -> List[Image.Image]:
+    refs = []
+    for img in images[:10]:
+        if img is None:
+            continue
+        if not isinstance(img, Image.Image):
+            try:
+                img = Image.fromarray(np.asarray(img))
+            except Exception:
+                continue
+        refs.append(img.convert("RGB"))
+    return refs
+
+
+def generate_video(prompt: str,
+                   negative_prompt: str = "",
+                   ref_images: Optional[List[Image.Image]] = None,
+                   num_inference_steps: int = 30,
+                   guidance_scale: float = 7.0,
+                   seed: Optional[int] = None,
+                   duration_seconds: int = 5,
+                   fps: int = 16) -> Tuple[str, int, int]:
+    if not prompt and not ref_images:
+        raise ValueError("Provide a prompt and/or at least one reference image.")
+
+    generator = torch.Generator(device=DEVICE)
+    if seed is None:
+        seed = int(time.time() * 1000) % 2**31
+    generator = generator.manual_seed(seed)
+
+    refs = _load_refs(ref_images or [])
+
+    all_frames = []
+    if not refs:
+        video_output = PIPE(prompt=prompt,
+                            negative_prompt=negative_prompt or None,
+                            num_inference_steps=int(num_inference_steps),
+                            guidance_scale=float(guidance_scale),
+                            generator=generator)
+        frames = video_output.frames[0]
+        all_frames.extend(frames)
+    else:
+        for ref in refs:
+            video_output = PIPE(image=ref,
+                                prompt=prompt or None,
+                                negative_prompt=negative_prompt or None,
+                                num_inference_steps=int(num_inference_steps),
+                                guidance_scale=float(guidance_scale),
+                                generator=generator)
+            frames = video_output.frames[0]
+            all_frames.extend(frames)
+
+    if not all_frames:
+        raise RuntimeError("No frames generated.")
+
+    seconds = _clamp_duration_seconds(duration_seconds)
+    target_frames = max(fps * seconds, fps)
+    if len(all_frames) < target_frames:
+        loops = int(math.ceil(target_frames / len(all_frames)))
+        all_frames = (all_frames * loops)[:target_frames]
+    else:
+        all_frames = all_frames[:target_frames]
+
+    tmpdir = tempfile.mkdtemp(prefix="ltx_video_")
+    out_path = os.path.join(tmpdir, "output.mp4")
+    export_to_video(all_frames, out_path, fps=fps)
+    return out_path, seconds, seed
+
+
+# Gradio UI
+CSS = """
+#seed {min-width: 100px}
+"""
+
+def ui_infer(prompt, negative_prompt, images, steps, guidance, seed, duration, fps):
+    try:
+        out_path, used_seconds, used_seed = generate_video(
+            prompt=prompt or "",
+            negative_prompt=negative_prompt or "",
+            ref_images=images or [],
+            num_inference_steps=int(steps),
+            guidance_scale=float(guidance),
+            seed=int(seed) if seed is not None and str(seed).strip() != "" else None,
+            duration_seconds=int(duration),
+            fps=int(fps),
+        )
+        return out_path, f"Duration: {used_seconds}s | Seed: {used_seed}", gr.update(visible=True)
+    except Exception as e:
+        return None, f"Error: {type(e).__name__}: {e}", gr.update(visible=False)
+
+with gr.Blocks(css=CSS, title="LTX-Video Hybrid Text+Image (Offline-ready)") as demo:
+    gr.Markdown("**LTX-Video** hybrid text+image generation. Up to 10 reference images. Duration 1s–10m.")
+
+    with gr.Row():
+        with gr.Column(scale=2):
+            prompt_in = gr.Textbox(label="Prompt", placeholder="Describe the scene", lines=2)
+            negative_in = gr.Textbox(label="Negative Prompt", lines=1)
+            gallery = gr.Gallery(label="Reference Images (0–10)", columns=5, preview=True, height=200)
+            file_uploader = gr.File(label="Upload images", file_count="multiple", type="filepath")
+        with gr.Column(scale=1):
+            steps_in = gr.Slider(4, 100, value=30, step=1, label="Inference Steps")
+            guidance_in = gr.Slider(0.0, 15.0, value=7.0, step=0.5, label="Guidance Scale")
+            duration_in = gr.Slider(1, 600, value=5, step=1, label="Duration (seconds)")
+            fps_in = gr.Slider(4, 30, value=16, step=1, label="FPS")
+            seed_in = gr.Number(label="Seed (optional)")
+            run_btn = gr.Button("Generate", variant="primary")
+
+    with gr.Row():
+        video_out = gr.Video(label="Output", interactive=False)
+        info_out = gr.Markdown()
+    download_out = gr.File(label="Download MP4", visible=False)
+
+    def _files_to_images(file_list):
+        pil_list = []
+        if not file_list:
+            return []
+        for f in file_list[:10]:
+            try:
+                img = Image.open(f.name if hasattr(f, 'name') else f)
+                pil_list.append(img.convert('RGB'))
+            except Exception:
+                continue
+        return pil_list
+
+    def sync_gallery(files):
+        return _files_to_images(files)
+
+    file_uploader.change(fn=sync_gallery, inputs=[file_uploader], outputs=[gallery])
+
+    run_btn.click(
+        fn=ui_infer,
+        inputs=[prompt_in, negative_in, gallery, steps_in, guidance_in, seed_in, duration_in, fps_in],
+        outputs=[video_out, info_out, download_out]
+    )
+
+    video_out.change(lambda v: v, inputs=[video_out], outputs=[download_out])
+
+try:
+    import google.colab  # noqa: F401
+    IS_COLAB = True
+except Exception:
+    IS_COLAB = False
+
+if __name__ == "__main__" or IS_COLAB:
+    demo.launch(share=False, inbrowser=False)


### PR DESCRIPTION
Add a Jupyter notebook with an offline-ready Gradio UI for LTX-Video, supporting hybrid text/image input, multiple references, and adjustable duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-51ee09d4-64b9-4909-b28c-50285a4ac97f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51ee09d4-64b9-4909-b28c-50285a4ac97f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

